### PR TITLE
catches deserialisation errors caused by upstream API issues

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -256,7 +256,13 @@ async fn main() -> anyhow::Result<()> {
 
             let mut items = Vec::new();
             for api in apis {
-                items.extend(api.list(&Default::default()).await?.items);
+                match api.list(&Default::default()).await {
+                    Ok(x) => items.extend(x.items),
+                    Err(_) => {
+                        println!("\tFailed to list items in {}", api.resource_url(),);
+                        continue;
+                    }
+                }
             }
 
             if items.is_empty() {


### PR DESCRIPTION
Kinda fixes #1, moreso hides and skips the problem until upstream the API server is fixed to return the `items` key in the response
